### PR TITLE
Fix the bug: copy wrong text from context menu

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,11 +9,11 @@ chrome.runtime.onInstalled.addListener(function () {
 })
 
 chrome.contextMenus.onClicked.addListener(function (_, tab) {
-  const text = createLinkForTab(tab)
-
-  chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    func: writeTextToClipboard,
-    args: [text]
+  createLinkForTab(tab).then((text) => {
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: writeTextToClipboard,
+      args: [text]
+    })
   })
 })


### PR DESCRIPTION
At v1.5.0, this extension copies wrong text like `[obj Object]` to a user's clipboard when clicking the context menu provided this extension. 

This PR provides a patch to fix this bug.