### PR TITLE
Add 'copy as quotation' to context menu

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -10,10 +10,29 @@ chrome.runtime.onInstalled.addListener(function () {
     id: 'copy-for-scrapbox',
     title: 'Copy [URL PageTitle]'
   })
+  chrome.contextMenus.create({
+    id: 'copy-selection-as-quotation',
+    contexts: ["selection"],
+    title: "Copy as Quotation"
+  })
 })
 
 chrome.contextMenus.onClicked.addListener(function (info, tab) {
-  createLinkForTab(tab).then((text) => {
+  let contextMenuWork;
+  switch(info.menuItemId) {
+    case "copy-for-scrapbox":
+      contextMenuWork = createLinkForTab(tab)
+      break;
+    case "copy-selection-as-quotation":
+      contextMenuWork = createLinkForTab(tab)
+        .then((text) => (`> ${info.selectionText}\n> ${text}`))
+      break;
+    default:
+      console.warn(`Caught undefined menuItemId: ${info.menuItemId}`)
+      return;
+  }
+
+  contextMenuWork.then((text) => {
     chrome.scripting.executeScript({
       target: { tabId: tab.id },
       func: writeTextToClipboard,

--- a/src/context_menu/handler_repository.js
+++ b/src/context_menu/handler_repository.js
@@ -9,13 +9,13 @@ export default class {
     this.handlers[handlerInfo.id] = handlerInfo
   }
 
-  async getHandler(menuId) {
+  getHandler(menuId) {
     const handler = this.handlers[menuId]?.handler
 
     return handler
   }
 
   getContextMenuInfo() {
-    return Object.values(this.handlers).map(({ id, contexts }) => ({ id, contexts }))
+    return Object.values(this.handlers).map(({ id, title, contexts }) => ({ id, title, contexts }))
   }
 }

--- a/src/context_menu/handler_repository.js
+++ b/src/context_menu/handler_repository.js
@@ -1,0 +1,17 @@
+export default class {
+  handlers = {}
+
+  registerHandler(handlerInfo) {
+    if (this.handlers[handlerInfo.id]) {
+      throw new Error('Handler already registered')
+    }
+
+    this.handlers[handlerInfo.id] = handlerInfo
+  }
+
+  async getHandler(menuId) {
+    const handler = this.handlers[menuId]?.handler
+
+    return handler
+  }
+}

--- a/src/context_menu/handler_repository.js
+++ b/src/context_menu/handler_repository.js
@@ -14,4 +14,8 @@ export default class {
 
     return handler
   }
+
+  getContextMenuInfo() {
+    return Object.values(this.handlers).map(({ id, contexts }) => ({ id, contexts }))
+  }
 }

--- a/src/context_menu/index.js
+++ b/src/context_menu/index.js
@@ -1,0 +1,54 @@
+import ContextMenuRepository from './handler_repository.js'
+import { createLinkForTab } from '../link.js';
+import { writeTextToClipboard } from '../clipboard.js';
+import { sendTrackEvent } from '../google-analytics.js';
+
+const repository = new ContextMenuRepository()
+
+repository.registerHandler({
+  id: 'copy-for-scrapbox',
+  title: 'Copy [URL PageTitle]',
+  handler: async (info, tab) => {
+    createLinkForTab(tab).then((text) => {
+      chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: writeTextToClipboard,
+        args: [text]
+      })
+    }).then(() => {
+      sendTrackEvent({
+        name: 'context_menu',
+        params: {
+          id: info.menuItemId
+        }
+      })
+    })
+  }
+})
+
+repository.registerHandler({
+  id: 'copy-selection-as-quotation',
+  title: 'Copy as Quotation',
+  contexts: ['selection'],
+  handler: async (info, tab) => {
+    createLinkForTab(tab)
+    .then((text) => (`> ${info.selectionText}\n> ${text}`))
+    .then((text) => {
+      chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: writeTextToClipboard,
+        args: [text]
+      })
+    }).then(() => {
+      sendTrackEvent({
+        name: 'context_menu',
+        params: {
+          id: info.menuItemId
+        }
+      })
+    })
+  }
+})
+
+
+export default repository;

--- a/test/context_menu/repository.test.js
+++ b/test/context_menu/repository.test.js
@@ -28,43 +28,45 @@ describe('ContextMenuRepository', () => {
     })
   })
 
-  it('returns a context menu handler for a given menuId', async () => {
-    const repository = new ContextMenuRepository()
-    repository.registerHandler({
-      id: 'copy-for-scrapbox',
-      title: 'Copy [URL PageTitle]',
-      handler: async () => { return 'fake value'}
-    })
-
-    const handler = await repository.getHandler('copy-for-scrapbox')
-    expect(handler()).resolves.toEqual('fake value')
-  })
-
-  describe('When no handler is registered', () => {
-    it('returns undefined', async () => {
-      const repository = new ContextMenuRepository()
-      const handler = await repository.getHandler('copy-for-scrapbox')
-
-      expect(handler).toBeUndefined()
-    })
-  })
-
-  describe('When multiple handlers are registered', () => {
-    it('returns the handler for the given menuId', async () => {
+  describe('#getHandler', () => {
+    it('returns a context menu handler for a given menuId', async () => {
       const repository = new ContextMenuRepository()
       repository.registerHandler({
         id: 'copy-for-scrapbox',
         title: 'Copy [URL PageTitle]',
         handler: async () => { return 'fake value'}
       })
-      repository.registerHandler({
-        id: 'another-handeler',
-        title: 'Another Handler',
-        handler: async () => { return 'another fake value'}
-      })
 
-      const handler = await repository.getHandler('another-handeler')
-      expect(handler()).resolves.toEqual('another fake value')
+      const handler = await repository.getHandler('copy-for-scrapbox')
+      expect(handler()).resolves.toEqual('fake value')
+    })
+
+    describe('When no handler is registered', () => {
+      it('returns undefined', async () => {
+        const repository = new ContextMenuRepository()
+        const handler = await repository.getHandler('copy-for-scrapbox')
+
+        expect(handler).toBeUndefined()
+      })
+    })
+
+    describe('When multiple handlers are registered', () => {
+      it('returns the handler for the given menuId', async () => {
+        const repository = new ContextMenuRepository()
+        repository.registerHandler({
+          id: 'copy-for-scrapbox',
+          title: 'Copy [URL PageTitle]',
+          handler: async () => { return 'fake value'}
+        })
+        repository.registerHandler({
+          id: 'another-handeler',
+          title: 'Another Handler',
+          handler: async () => { return 'another fake value'}
+        })
+
+        const handler = await repository.getHandler('another-handeler')
+        expect(handler()).resolves.toEqual('another fake value')
+      })
     })
   })
 })

--- a/test/context_menu/repository.test.js
+++ b/test/context_menu/repository.test.js
@@ -28,6 +28,20 @@ describe('ContextMenuRepository', () => {
     })
   })
 
+  describe('#getContextMenuInfo', () => {
+    it('returns all context menu info', () => {
+      const repository = new ContextMenuRepository()
+      const handlerInfo = {
+        id: 'some-handler',
+        contexts: ['selection'],
+        handler: async () => { return 'fake value'}
+      }
+      repository.registerHandler(handlerInfo)
+
+      expect(repository.getContextMenuInfo()).toEqual([{id: 'some-handler', contexts: ['selection']}])
+    })
+  })
+
   describe('#getHandler', () => {
     it('returns a context menu handler for a given menuId', async () => {
       const repository = new ContextMenuRepository()

--- a/test/context_menu/repository.test.js
+++ b/test/context_menu/repository.test.js
@@ -1,0 +1,70 @@
+import ContextMenuRepository from '../../src/context_menu/handler_repository.js'
+
+describe('ContextMenuRepository', () => {
+  describe('#registerHandler', () => {
+    it('returns undefined', () => {
+      const repository = new ContextMenuRepository()
+      const handlerInfo = {
+        id: 'some-handler',
+        contexts: ['selection'],
+        handler: async () => { return 'fake value'}
+      }
+
+      expect(repository.registerHandler(handlerInfo)).toBeUndefined()
+    })
+
+    describe('When conflicting handler is registered', () => {
+      it('throws an error', () => {
+        const repository = new ContextMenuRepository()
+        const handlerInfo = {
+          id: 'some-handler',
+          contexts: ['selection'],
+          handler: async () => { return 'fake value'}
+        }
+
+        expect(repository.registerHandler(handlerInfo)).toBeUndefined()
+        expect(() => repository.registerHandler(handlerInfo)).toThrowError('Handler already registered')
+      })
+    })
+  })
+
+  it('returns a context menu handler for a given menuId', async () => {
+    const repository = new ContextMenuRepository()
+    repository.registerHandler({
+      id: 'copy-for-scrapbox',
+      title: 'Copy [URL PageTitle]',
+      handler: async () => { return 'fake value'}
+    })
+
+    const handler = await repository.getHandler('copy-for-scrapbox')
+    expect(handler()).resolves.toEqual('fake value')
+  })
+
+  describe('When no handler is registered', () => {
+    it('returns undefined', async () => {
+      const repository = new ContextMenuRepository()
+      const handler = await repository.getHandler('copy-for-scrapbox')
+
+      expect(handler).toBeUndefined()
+    })
+  })
+
+  describe('When multiple handlers are registered', () => {
+    it('returns the handler for the given menuId', async () => {
+      const repository = new ContextMenuRepository()
+      repository.registerHandler({
+        id: 'copy-for-scrapbox',
+        title: 'Copy [URL PageTitle]',
+        handler: async () => { return 'fake value'}
+      })
+      repository.registerHandler({
+        id: 'another-handeler',
+        title: 'Another Handler',
+        handler: async () => { return 'another fake value'}
+      })
+
+      const handler = await repository.getHandler('another-handeler')
+      expect(handler()).resolves.toEqual('another fake value')
+    })
+  })
+})


### PR DESCRIPTION
This pull-request provides new context menu that when selecting contents on a tab and clicking the menu, the selected contents and its link to the page are copied as a quotation in Scrapbox notation as follows: 

```
> This sentence is selected
> [This page https://www.example.com/]
```
